### PR TITLE
Implement encounter tracker

### DIFF
--- a/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.css
+++ b/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.css
@@ -1,5 +1,11 @@
 .character-conditions-form-control {
     display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+.character-conditions-form-control__conditions {
+    display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     gap: .5em;

--- a/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.css
+++ b/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.css
@@ -1,0 +1,6 @@
+.character-conditions-form-control {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: .5em;
+}

--- a/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx
+++ b/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx
@@ -1,0 +1,77 @@
+// Styling
+import './CharacterConditionsFormControl.css';
+
+// Custom hooks
+import useRequestState from "../../../hooks/useRequestState.js";
+
+// Services
+import characterConditionsService from "../../../services/characterConditionsService.js";
+
+// Components
+import Spinner from "../../ui/Spinner/Spinner.jsx";
+import ConditionBadge from "../../ui/ConditionBadge/ConditionBadge.jsx";
+
+// TODO: This component can be extended to include the rendering of the readonly variant too.
+function CharacterConditionsFormControl({characterId, currentConditions, onChange}) {
+  const {data: conditionsFromAPI, loading: conditionsLoading} = useRequestState(
+    characterConditionsService.getConditionsIndex({useCache: true}),
+    {executeOnMount: true, isAbortable: true}
+  );
+
+  const availableCharacterConditions = () => {
+    if (!conditionsFromAPI || conditionsLoading) {
+      return [];
+    }
+
+    return conditionsFromAPI.results.filter(conditionFromAPI => !currentConditions.includes(conditionFromAPI.name));
+  }
+
+  const handleConditionChange = (condition, action) => {
+    if (!['add', 'remove'].includes(action)) {
+      return
+    }
+
+    const updatedConditions = action === 'add'
+      ? [...currentConditions, condition]
+      : currentConditions.filter(c => c !== condition);
+
+    onChange(updatedConditions);
+  };
+
+  return (<>
+    {conditionsLoading && <Spinner size='large'/>}
+    {!conditionsLoading && (<>
+      <section>
+        <h3>Huidige conditions:</h3>
+        <div className="character-conditions-form-control">
+          {currentConditions.map(condition => (
+            <ConditionBadge
+              key={`${characterId}.${condition}`}
+              label={condition}
+              onClick={() => handleConditionChange(condition, 'remove')}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h3>Beschikbare conditions:</h3>
+        <div className="character-conditions-form-control">
+          {availableCharacterConditions().map(condition => (
+            <ConditionBadge
+              key={`${characterId}.${condition.name}`}
+              label={condition.name}
+              onClick={() => handleConditionChange(condition.name, 'add')}
+            />
+          ))}
+        </div>
+      </section>
+
+      <p>
+        Klik op een condition om te (de)selecteren.
+      </p>
+    </>)}
+  </>);
+}
+
+export default CharacterConditionsFormControl;

--- a/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx
+++ b/src/components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx
@@ -38,40 +38,42 @@ function CharacterConditionsFormControl({characterId, currentConditions, onChang
     onChange(updatedConditions);
   };
 
-  return (<>
-    {conditionsLoading && <Spinner size='large'/>}
-    {!conditionsLoading && (<>
-      <section>
-        <h3>Huidige conditions:</h3>
-        <div className="character-conditions-form-control">
-          {currentConditions.map(condition => (
-            <ConditionBadge
-              key={`${characterId}.${condition}`}
-              label={condition}
-              onClick={() => handleConditionChange(condition, 'remove')}
-            />
-          ))}
-        </div>
-      </section>
+  return (
+    <div className="character-conditions-form-control">
+      {conditionsLoading && <Spinner size='large'/>}
+      {!conditionsLoading && (<>
+        <section>
+          <h3>Huidige conditions:</h3>
+          <div className="character-conditions-form-control__conditions">
+            {currentConditions.map(condition => (
+              <ConditionBadge
+                key={`${characterId}.${condition}`}
+                label={condition}
+                onClick={() => handleConditionChange(condition, 'remove')}
+              />
+            ))}
+          </div>
+        </section>
 
-      <section>
-        <h3>Beschikbare conditions:</h3>
-        <div className="character-conditions-form-control">
-          {availableCharacterConditions().map(condition => (
-            <ConditionBadge
-              key={`${characterId}.${condition.name}`}
-              label={condition.name}
-              onClick={() => handleConditionChange(condition.name, 'add')}
-            />
-          ))}
-        </div>
-      </section>
+        <section>
+          <h3>Beschikbare conditions:</h3>
+          <div className="character-conditions-form-control__conditions">
+            {availableCharacterConditions().map(condition => (
+              <ConditionBadge
+                key={`${characterId}.${condition.name}`}
+                label={condition.name}
+                onClick={() => handleConditionChange(condition.name, 'add')}
+              />
+            ))}
+          </div>
+        </section>
 
-      <p>
-        Klik op een condition om te (de)selecteren.
-      </p>
-    </>)}
-  </>);
+        <p>
+          Klik op een condition om te (de)selecteren.
+        </p>
+      </>)}
+    </div>
+  );
 }
 
 export default CharacterConditionsFormControl;

--- a/src/components/ui/CharacterCard/CharacterCard.css
+++ b/src/components/ui/CharacterCard/CharacterCard.css
@@ -1,5 +1,6 @@
 .character-card {
     display: flex;
+    flex-grow: 1;
     flex-direction: column;
     align-items: center;
     gap: .5em;
@@ -11,7 +12,14 @@
 .character-card--small,
 .character-card--medium {
     flex-direction: row;
-    width: 400px;
+}
+
+.character-card--small {
+    flex-basis: 300px;
+}
+
+.character-card--medium {
+    flex-basis: 400px;
 }
 
 .character-card--small .character-card__image {

--- a/src/components/ui/Dialog/Dialog.css
+++ b/src/components/ui/Dialog/Dialog.css
@@ -21,4 +21,6 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+    gap: .5em;
+    margin-top: .5em;
 }

--- a/src/components/ui/Dialog/Dialog.jsx
+++ b/src/components/ui/Dialog/Dialog.jsx
@@ -8,7 +8,7 @@ import {useEffect, useRef} from "react";
 import Button from "../Button/Button.jsx";
 import Panel from "../Panel/Panel.jsx";
 
-function Dialog({isOpen, closeDialogLabel, closeDialog, children}) {
+function Dialog({isOpen, closeDialogLabel, closeDialog, confirmDialogLabel, onConfirmDialog, children}) {
   const dialogRef = useRef();
 
   useEffect(() => {
@@ -32,6 +32,14 @@ function Dialog({isOpen, closeDialogLabel, closeDialog, children}) {
           </div>
 
           <div className="dialog__controls">
+            {confirmDialogLabel && onConfirmDialog && (
+              <Button
+                type="button"
+                label={confirmDialogLabel}
+                onClick={onConfirmDialog}
+              />
+            )}
+
             <Button
               type="button"
               label={closeDialogLabel}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.css
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.css
@@ -8,6 +8,7 @@
 .encounter-tracker__table {
     display: flex;
     flex-direction: column;
+    width: 100%;
     min-width: 800px;
     gap: .5em;
 }
@@ -15,11 +16,11 @@
 .encounter-tracker__table-header,
 .encounter-tracker__table-row {
     display: grid;
-    grid-template-columns: 2fr .875fr .875fr 1.25fr auto;
+    grid-template-columns: 2fr .75fr .5fr .5fr 1.5fr .75fr;
 }
 
 .encounter-tracker__table-header {
-    font-size: 1.2em;
+    font-size: 1em;
 }
 
 .encounter-tracker__centered-heading {

--- a/src/pages/encounter-tracker/EncounterTrackerPage.css
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.css
@@ -48,3 +48,9 @@
 .encounter-tracker__active-character {
     box-shadow: 0 0 0 5px var(--color-secondary);
 }
+
+.encounter-tracker__dialog {
+    display: flex;
+    flex-direction: column;
+    gap: .5em;
+}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.css
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.css
@@ -44,3 +44,7 @@
     flex-wrap: wrap;
     gap: .25em;
 }
+
+.encounter-tracker__active-character {
+    box-shadow: 0 0 0 5px var(--color-secondary);
+}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.css
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.css
@@ -1,0 +1,46 @@
+.encounter-tracker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.5em;
+}
+
+.encounter-tracker__table {
+    display: flex;
+    flex-direction: column;
+    min-width: 800px;
+    gap: .5em;
+}
+
+.encounter-tracker__table-header,
+.encounter-tracker__table-row {
+    display: grid;
+    grid-template-columns: 2fr .875fr .875fr 1.25fr auto;
+}
+
+.encounter-tracker__table-header {
+    font-size: 1.2em;
+}
+
+.encounter-tracker__centered-heading {
+    text-align: center;
+}
+
+.encounter-tracker__table-cell,
+.encounter-tracker__table-centered-cell {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .5em;
+}
+
+.encounter-tracker__table-centered-cell {
+    justify-content: center;
+}
+
+.encounter-tracker__conditions-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .25em;
+}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -11,6 +11,9 @@ import calculateInitiative from "../../helpers/calculateInitiative.js";
 import {useEffect, useState} from "react";
 import {useForm} from "react-hook-form";
 
+// Custom hooks
+import {useToaster} from "../../contexts/ToasterContext.jsx";
+
 // Components
 import Panel from "../../components/ui/Panel/Panel.jsx";
 import Button from "../../components/ui/Button/Button.jsx";
@@ -80,6 +83,8 @@ function EncounterTrackerPage() {
       newConditions: []
     }
   });
+  
+  const {showToast} = useToaster();
 
   // Watches
   const selectedCharacters = watch('selectedCharacters');
@@ -222,6 +227,9 @@ function EncounterTrackerPage() {
     setValue('conditions', updatedConditions)
 
     setDialog({isOpen: false, mode: 'inactive', character: null});
+
+    const updatedCharacterName = selectedCharacters.find(character => character.id === dialog.character.id).name;
+    showToast(`${updatedCharacterName} voelt zich zo goed als nieuw! Of niet...`, 'success');
   }
 
   const onDeleteCharacterSubmit = () => {

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -114,6 +114,13 @@ function EncounterTrackerPage() {
     setValue('selectedCharacters',
       selectedCharacters.filter(selectedCharacter => selectedCharacter.id !== dialog.character.id)
     );
+
+    // Underscores are discards, this mechanism separates the deleted initiatives & conditions from te remaining ones.
+    const {[dialog.character.id]: _, ...remainingInitiatives} = initiatives;
+    setValue('initiatives', remainingInitiatives);
+
+    const {[dialog.character.id]: __, ...remainingConditions} = conditions;
+    setValue('conditions', remainingConditions)
   }
 
   const isStepValid = () => {

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -8,7 +8,7 @@ import {PencilIcon, TrashIcon} from "@phosphor-icons/react";
 import calculateInitiative from "../../helpers/calculateInitiative.js";
 
 // Framework dependencies
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {useForm} from "react-hook-form";
 
 // Components
@@ -38,6 +38,7 @@ function EncounterTrackerPage() {
 
   const [currentStepNumber, setCurrentStepNumber] = useState(0);
   const [showNextStepButton, setShowNextStepButton] = useState(true);
+  const [activeCharacter, setActiveCharacter] = useState(null);
 
   const {
     register,
@@ -60,6 +61,9 @@ function EncounterTrackerPage() {
 
   // Derived state (newly learnt concept).
   const isLastStep = currentStepNumber === steps.length - 1;
+  const sortedCharacters = [...selectedCharacters].sort((left, right) => {
+    return calculateInitiative(initiatives[right.id], right.dexterity) - calculateInitiative(initiatives[left.id], left.dexterity);
+  });
 
   const handleNextStepClick = async () => {
     // Manually trigger current step validation in case the user has not interacted with the current step.
@@ -74,6 +78,12 @@ function EncounterTrackerPage() {
     if (nextStep) {
       setCurrentStepNumber(nextStep.number);
     }
+  }
+
+  const handleNextActiveCharacterClick = () => {
+    const currentActiveCharacterIndex = sortedCharacters.indexOf(activeCharacter);
+    const nextActiveCharacterIndex = (currentActiveCharacterIndex + 1) % sortedCharacters.length;
+    setActiveCharacter(sortedCharacters[nextActiveCharacterIndex]);
   }
 
   const isStepValid = () => {
@@ -122,6 +132,12 @@ function EncounterTrackerPage() {
     }
   }
 
+  useEffect(() => {
+    if (isLastStep) {
+      setActiveCharacter(sortedCharacters[0]);
+    }
+  }, [isLastStep]);
+
   return (
     <Panel
       title={steps[currentStepNumber].title}
@@ -152,12 +168,10 @@ function EncounterTrackerPage() {
               <h2 className="encounter-tracker__heading">Beheer</h2>
             </div>
 
-            {[...selectedCharacters].sort((left, right) => {
-              return calculateInitiative(initiatives[right.id], right.dexterity) - calculateInitiative(initiatives[left.id], left.dexterity);
-            }).map(character => (
+            {sortedCharacters.map(character => (
               <div
                 key={character.id}
-                className="encounter-tracker__table-row"
+                className={`encounter-tracker__table-row ${activeCharacter?.id === character.id ? 'encounter-tracker__active-character' : ''}`}
               >
                 <div className="encounter-tracker__table-cell">
                   <CharacterCard character={character} variant='small'/>
@@ -192,6 +206,7 @@ function EncounterTrackerPage() {
 
           <Button
             label="Volgende beurt"
+            onClick={handleNextActiveCharacterClick}
           />
         </div>
       )}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -262,7 +262,8 @@ function EncounterTrackerPage() {
             <div className="encounter-tracker__table-header">
               <h2 className="encounter-tracker__heading">Personage</h2>
               <h2 className="encounter-tracker__centered-heading">Initiatief</h2>
-              <h2 className="encounter-tracker__centered-heading">Hit points</h2>
+              <h2 className="encounter-tracker__centered-heading">HP</h2>
+              <h2 className="encounter-tracker__centered-heading">AC</h2>
               <h2 className="encounter-tracker__heading">Conditions</h2>
               <h2 className="encounter-tracker__heading">Beheer</h2>
             </div>
@@ -282,6 +283,10 @@ function EncounterTrackerPage() {
 
                 <div className="encounter-tracker__table-centered-cell">
                   <p>{character.currentHitPoints}/{character.maxHitPoints}</p>
+                </div>
+
+                <div className="encounter-tracker__table-centered-cell">
+                  <p>{character.armorClass}</p>
                 </div>
 
                 <div className="encounter-tracker__table-cell">

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -10,6 +10,7 @@ import calculateInitiative from "../../helpers/calculateInitiative.js";
 // Framework dependencies
 import {useEffect, useState} from "react";
 import {useForm} from "react-hook-form";
+import {useNavigate} from "react-router-dom";
 
 // Custom hooks
 import {useToaster} from "../../contexts/ToasterContext.jsx";
@@ -85,6 +86,7 @@ function EncounterTrackerPage() {
   });
 
   const {showToast} = useToaster();
+  const navigate = useNavigate();
 
   // Watches
   const selectedCharacters = watch('selectedCharacters');
@@ -201,6 +203,15 @@ function EncounterTrackerPage() {
         onConfirmDialog: editCharacterHandleSubmit(onEditCharacterSubmit)
       };
     }
+
+    if (dialog.mode === 'end-encounter') {
+      return {
+        ...defaultProperties,
+        closeDialogLabel: 'Nee',
+        confirmDialogLabel: 'Ja',
+        onConfirmDialog: onEndEncounterSubmit
+      }
+    }
   }
 
   const onEditCharacterSubmit = (data) => {
@@ -242,6 +253,10 @@ function EncounterTrackerPage() {
     setDialog({isOpen: false, mode: 'inactive', character: null});
   }
 
+  const onEndEncounterSubmit = () => {
+    navigate('/');
+  }
+
   useEffect(() => {
     if (isLastStep) {
       setActiveCharacter(sortedCharacters[0]);
@@ -254,6 +269,7 @@ function EncounterTrackerPage() {
       panelButton={showNextStepButton && isLastStep ? (
         <Button
           label="Gevecht beëindigen"
+          onClick={() => {setDialog({isOpen: true, mode: 'end-encounter', character: null})}}
         />
       ) : (
         <Button
@@ -361,8 +377,7 @@ function EncounterTrackerPage() {
 
           {dialog.mode === 'edit' && (<>
             <h3><b>
-              Gevechtseigenschappen van&nbsp;
-              <u>{dialog.character.name}</u>.
+              Gevechtseigenschappen van <u>{dialog.character.name}</u>.
             </b></h3>
 
             <form>
@@ -412,6 +427,21 @@ function EncounterTrackerPage() {
                 }
               />
             </form>
+          </>)}
+
+          {dialog.mode === 'end-encounter' && (<>
+            <h3><b>
+              Weet je zeker dat je het gevecht wilt beëindigen?
+            </b></h3>
+
+            <p><em>
+              Dit betekent dat je wordt teruggestuurd naar het hoofdscherm.
+            </em></p>
+
+            <p>
+              <b>LET OP!</b> Houd er rekening mee dat lopende gevechten momenteel <b>niet worden opgeslagen</b>.
+              Je voortgang gaat verloren en kan niet worden hersteld.
+            </p>
           </>)}
         </div>
       </Dialog>

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -83,7 +83,7 @@ function EncounterTrackerPage() {
       newConditions: []
     }
   });
-  
+
   const {showToast} = useToaster();
 
   // Watches

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -18,6 +18,7 @@ import CharacterCard from "../../components/ui/CharacterCard/CharacterCard.jsx";
 import ConditionBadge from "../../components/ui/ConditionBadge/ConditionBadge.jsx";
 import Dialog from "../../components/ui/Dialog/Dialog.jsx";
 import NumberFormControl from "../../components/form-controls/NumberFormControl/NumberFormControl.jsx";
+import CharacterConditionsFormControl from "../../components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx";
 
 // Step components
 import EncounterTrackerConditionSelection from "./encounter-tracker-condition-selection/EncounterTrackerConditionSelection.jsx";
@@ -68,6 +69,8 @@ function EncounterTrackerPage() {
     handleSubmit: editCharacterHandleSubmit,
     reset: editCharacterReset,
     formState: { errors: editCharacterErrors },
+    setValue: editCharacterSetValue,
+    watch: editCharacterWatch
   } = useForm({
     mode: 'onChange',
     defaultValues: {
@@ -392,6 +395,13 @@ function EncounterTrackerPage() {
                   minimumValue: 1,
                   maximumValue: 20
                 }}
+              />
+
+              <CharacterConditionsFormControl
+                currentConditions={editCharacterWatch('newConditions')}
+                onChange={(updatedConditions) =>
+                  editCharacterSetValue('newConditions', updatedConditions)
+                }
               />
             </form>
           </>)}

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -87,7 +87,7 @@ function EncounterTrackerPage() {
   }
 
   const handleHighlightNextActiveCharacter = () => {
-    const currentActiveCharacterIndex = sortedCharacters.indexOf(activeCharacter);
+    const currentActiveCharacterIndex = sortedCharacters.findIndex(character => character.id === activeCharacter.id);
     const nextActiveCharacterIndex = (currentActiveCharacterIndex + 1) % sortedCharacters.length;
     setActiveCharacter(sortedCharacters[nextActiveCharacterIndex]);
   }
@@ -157,11 +157,11 @@ function EncounterTrackerPage() {
         closeDialogLabel: 'Nee',
         confirmDialogLabel: 'Ja',
         onConfirmDialog: () => {
+          handleDeleteCharacter();
+
           if (dialog.character.id === activeCharacter.id) {
             handleHighlightNextActiveCharacter();
           }
-
-          handleDeleteCharacter();
 
           setDialog({isOpen: false, mode: 'inactive', character: null});
         }

--- a/src/pages/encounter-tracker/EncounterTrackerPage.jsx
+++ b/src/pages/encounter-tracker/EncounterTrackerPage.jsx
@@ -319,7 +319,7 @@ function EncounterTrackerPage() {
                         newCurrentHitPoints: character.currentHitPoints,
                         newArmorClass: character.armorClass,
                         newInitiative: initiatives[character.id],
-                        newConditions: conditions[character.id]
+                        newConditions: conditions[character.id] ?? []
                       });
                       setDialog({isOpen: true, mode: 'edit', character: character});
                     }}

--- a/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.css
+++ b/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.css
@@ -34,9 +34,3 @@
     flex-wrap: wrap;
     gap: .5em;
 }
-
-.condition-selection__dialog {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-}

--- a/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.css
+++ b/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.css
@@ -40,10 +40,3 @@
     flex-direction: column;
     gap: 1em;
 }
-
-.condition-selection__dialog-conditions {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: .5em;
-}

--- a/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.jsx
+++ b/src/pages/encounter-tracker/encounter-tracker-condition-selection/EncounterTrackerConditionSelection.jsx
@@ -7,52 +7,21 @@ import {PencilIcon} from "@phosphor-icons/react";
 // Framework dependencies
 import {useState} from "react";
 
-// Custom hooks
-import useRequestState from "../../../hooks/useRequestState.js";
-
-// Services
-import characterConditionsService from "../../../services/characterConditionsService.js";
-
 // Components
 import Button from "../../../components/ui/Button/Button.jsx";
 import Dialog from "../../../components/ui/Dialog/Dialog.jsx";
 import CharacterCard from "../../../components/ui/CharacterCard/CharacterCard.jsx";
 import ConditionBadge from "../../../components/ui/ConditionBadge/ConditionBadge.jsx";
-import Spinner from "../../../components/ui/Spinner/Spinner.jsx";
+import CharacterConditionsFormControl from "../../../components/form-controls/CharacterConditionsFormControl/CharacterConditionsFormControl.jsx";
 
 function EncounterTrackerConditionSelection({watch, setValue}) {
   const [dialog, setDialog] = useState({
     isOpen: false,
     characterId: null
   });
-  const {data: conditionsFromAPI, loading: conditionsLoading} = useRequestState(
-    characterConditionsService.getConditionsIndex({useCache: true}),
-    {executeOnMount: true, isAbortable: true}
-  );
 
   const characters = watch('selectedCharacters');
   const characterConditions = (characterId) => watch(`conditions.${characterId}`) ?? [];
-
-  const handleConditionUpdate = (characterId, condition, action) => {
-    if (characterId === null || !['add', 'remove'].includes(action)) {
-      return
-    }
-
-    const existingConditions = characterConditions(characterId);
-    const updatedConditions = action === 'add'
-      ? [...existingConditions, condition]
-      : existingConditions.filter(c => c !== condition);
-
-    setValue(`conditions.${characterId}`, updatedConditions);
-  };
-
-  const availableCharacterConditions = (characterId) => {
-    if (!conditionsFromAPI || conditionsLoading) {
-      return [];
-    }
-
-    return conditionsFromAPI.results.filter(conditionFromAPI => !characterConditions(characterId).includes(conditionFromAPI.name));
-  }
 
   return (
     <div className="encounter-tracker-condition-selection">
@@ -92,38 +61,12 @@ function EncounterTrackerConditionSelection({watch, setValue}) {
         closeDialog={() => setDialog({isOpen: false, characterId: null})}
       >
         <div className="condition-selection__dialog">
-          {conditionsLoading && <Spinner size='large'/>}
-          {!conditionsLoading && (<>
-            <section>
-              <h3>Huidige conditions:</h3>
-              <div className="condition-selection__dialog-conditions">
-                {characterConditions(dialog.characterId).map(condition => (
-                  <ConditionBadge
-                    key={`${dialog.characterId}.${condition}`}
-                    label={condition}
-                    onClick={() => handleConditionUpdate(dialog.characterId, condition, 'remove')}
-                  />
-                ))}
-              </div>
-            </section>
-
-            <section>
-              <h3>Beschikbare conditions:</h3>
-              <div className="condition-selection__dialog-conditions">
-                {availableCharacterConditions(dialog.characterId).map(condition => (
-                  <ConditionBadge
-                    key={`${dialog.characterId}.${condition.name}`}
-                    label={condition.name}
-                    onClick={() => handleConditionUpdate(dialog.characterId, condition.name, 'add')}
-                  />
-                ))}
-              </div>
-            </section>
-
-            <p>
-              Klik op een condition om te (de)selecteren.
-            </p>
-          </>)}
+          <CharacterConditionsFormControl
+            currentConditions={characterConditions(dialog.characterId)}
+            onChange={(updatedConditions) =>
+              setValue(`conditions.${dialog.characterId}`, updatedConditions)
+            }
+          />
         </div>
       </Dialog>
     </div>


### PR DESCRIPTION
# In this PR
This pull request continuous where #4 left off and implements the final part of the encounter tracker, the actual tracking of the encounter.

It is now possible to:
- Track an encounter's state, including:
  - Highlighting the active character.
  - Viewing initiative, HP, AC and conditions for all characters.
- Update an encounter's state by:
  - Clicking the next turn button to highlight the next active character.
  - Clicking a character's edit button to update it's initiative, HP, AC and conditions.
  - Clicking a character's delete button to remove it from the encounter.

And of course, all validations are in place 😎. This implementation was tricky at parts, but I learnt lots of new things!

# Impression of encounter tracking

https://github.com/user-attachments/assets/88d1c35e-2080-48c6-8f3c-71adea7da7e6

